### PR TITLE
mappers.TemplateFetcher: exclusive include config

### DIFF
--- a/chamberlain/mappers.py
+++ b/chamberlain/mappers.py
@@ -38,7 +38,7 @@ class TemplateFetcher():
             return []
         if self.forks_only and repo.fork():
             return []
-        if repo.name() in self.excludes():
+        if self.cfg.include.exists() and repo.name() not in self.cfg.include():
             return []
         return self.cfg.templates()
 

--- a/tests/chamberlain/mappers_test.py
+++ b/tests/chamberlain/mappers_test.py
@@ -37,6 +37,13 @@ class TemplateFetcherTest(unittest.TestCase):
         self.meta["exclude"] = ["repo_name"]
         self.assertEquals(self.fixture_templates(), [])
 
+    def test_included_repo_returns_nothing(self):
+        self.repo["owner"] = "bar"
+        self.repo["private"] = True
+        self.meta["owner"] = "bar"
+        self.meta["include"] = ["other_repo"]
+        self.assertEquals(self.fixture_templates(), [])
+
     def test_repo_takes_precedence(self):
         self.repo["owner"] = "bar"
         self.repo["private"] = True
@@ -64,6 +71,13 @@ class TemplateFetcherTest(unittest.TestCase):
         self.meta["owner"] = "bar"
         self.repo["private"] = True
         self.meta["repo"] = "repo_name"
+        self.assertEquals(self.fixture_templates(), ["a", "b"])
+
+    def test_repo_included(self):
+        self.repo["owner"] = "bar"
+        self.repo["private"] = True
+        self.meta["owner"] = "bar"
+        self.meta["include"] = ["repo_name"]
         self.assertEquals(self.fixture_templates(), ["a", "b"])
 
     def test_default_case(self):


### PR DESCRIPTION
Allow grouping of repos based on an inclusion principle. This way specific public / fork repos can be easily allowed.
