### PR TITLE
gh-sync: multi-variate template support

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 CHANGES
 =======
 
+* gh-sync: --template-vars flag
+* cli/command/templates: pep8 omfg shutup
+* requirements: strict versioning for pbr
 * gh-sync: prevent double API fetch
 * gh-sync: regular print out dir
 * gh-sync: rework


### PR DESCRIPTION
[Jenkins Job Builder (JJB) Docs for this feature](https://docs.openstack.org/infra/jenkins-job-builder/definition.html#default-values-for-template-variables)

Example run:

```
chamberlain gh-sync --repo adobe-platform/test local-instance {type}-integration-tests {owner}-{repo}-deploy --template-vars '{type}-integration-tests:{"type":["cron","dcos-cron"],"cron":["0 */3 * * *"]}'
Fetching github data for adobe-platform/test (org: adobe-platform)
INFO:github3:Building a url from ('https://api.github.com', 'repos', 'adobe-platform', 'test')
INFO:github3:Missed the cache building the url
INFO:github3:Attempting to get JSON information from a Response with status code 200 expecting 200
INFO:github3:JSON was returned
Fetched metadata for adobe-platform/test
{
  "fork": false,
  "name": "test",
  "full_name": "adobe-platform/test",
  "ssh_url": "git@github.com:adobe-platform/test.git",
  "owner": "adobe-platform",
  "id": 47307,
  "private": false,
  "html_url": "https://github.com/adobe-platform/test"
}
Generating templates in /Users/kran/.chamberlain/workspace/gh-sync/adobe-platform/test-1493933922
Cleaning /Users/kran/.chamberlain/workspace/gh-sync/adobe-platform/test-1493933922 ...
- {type}-integration-tests - vars found:
	- {u'cron': u'0 */3 * * *', u'type': u'cron'}
	- {u'cron': u'0 */3 * * *', u'type': u'dcos-cron'}
- {owner}-{repo}-deploy - no vars detected

======== Resulting YAML ========

- project:
    ghprauth: oauth-token
    ghurl: https://github.com/adobe-platform/test
    gitauth: rsa-key
    jobs:
    - {type}-integration-tests: {cron: 0 */3 * * *, type: cron}
    - {type}-integration-tests: {cron: 0 */3 * * *, type: dcos-cron}
    - '{owner}-{repo}-deploy'
    name: local-adobe-platform/test-project
    owner: adobe-platform
    repo: test
    repo_full_name: adobe-platform/test
    sshurl: git@github.com:adobe-platform/test.git
```